### PR TITLE
extend chart values

### DIFF
--- a/charts/radix-cluster-cleanup/templates/deployment.yaml
+++ b/charts/radix-cluster-cleanup/templates/deployment.yaml
@@ -14,29 +14,26 @@ spec:
       {{- include "radix-cluster-cleanup.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- if (.Values.metrics.enabled) }}
+      {{- if (.Values.metrics.enabled) }}
       annotations:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
         {{- if (.Values.metrics.annotations) }}
         {{- toYaml .Values.metrics.annotations | nindent 8 }}
         {{- end }}
-    {{- end }}
+      {{- end }}
       labels:
         {{- include "radix-cluster-cleanup.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "radix-cluster-cleanup.serviceAccountName" . }}
-    {{- with .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        supplementalGroups:
-          - 1000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           env:
@@ -60,19 +57,27 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
           securityContext:
-            privileged: false
-            readOnlyRootFilesystem: false
-            allowPrivilegeEscalation: false
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}          
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}        

--- a/charts/radix-cluster-cleanup/templates/serviceaccount.yaml
+++ b/charts/radix-cluster-cleanup/templates/serviceaccount.yaml
@@ -5,3 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "radix-cluster-cleanup.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}      

--- a/charts/radix-cluster-cleanup/values.yaml
+++ b/charts/radix-cluster-cleanup/values.yaml
@@ -14,6 +14,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set, a name is generated using the fullname template
   name: ""
+  # Annotations to add to the service account
+  annotations: {}
 
 image:
   repository: xx
@@ -37,3 +39,22 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  supplementalGroups:
+    - 1000
+
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+
+# Additional volumes to add to the radix-cluster-cleanup pod.
+volumes: []
+
+# Additional volume mounts to add to the radix-cluster-cleanup container.
+volumeMounts: []


### PR DESCRIPTION
Added chart values to allow configuration of service account annotations, pod and container security context and volumes + mounts