### PR TITLE
fix bug causing multiple appName fields appended to logger

### DIFF
--- a/charts/radix-cluster-cleanup/Chart.yaml
+++ b/charts/radix-cluster-cleanup/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: radix-cluster-cleanup
-version: 1.0.17
-appVersion: 1.0.17
+version: 1.0.18
+appVersion: 1.0.18

--- a/radix-cluster-cleanup/cmd/root.go
+++ b/radix-cluster-cleanup/cmd/root.go
@@ -187,15 +187,14 @@ func runFunctionPeriodically(ctx context.Context, someFunc func(ctx context.Cont
 }
 
 func getTooInactiveRrs(ctx context.Context, kubeClient *kube.Kube, inactivityLimit time.Duration, action string) ([]v1.RadixRegistration, error) {
-	logger := log.Ctx(ctx)
 	rrs, err := kubeClient.ListRegistrations(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var rrsForDeletion []v1.RadixRegistration
 	for _, rr := range rrs {
-		logger := logger.With().Str("appName", rr.Name).Logger()
-		ctx = logger.WithContext(ctx)
+		logger := log.Ctx(ctx).With().Str("appName", rr.Name).Logger()
+		ctx := logger.WithContext(ctx)
 
 		if isWhitelisted(rr) {
 			logger.Debug().Msg("RadixRegistration is whitelisted, skipping")

--- a/radix-cluster-cleanup/cmd/stopRrs.go
+++ b/radix-cluster-cleanup/cmd/stopRrs.go
@@ -62,8 +62,9 @@ func stopRrs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	for _, rr := range tooInactiveRrs {
-		ctx = log.Ctx(ctx).With().Str("appName", rr.Name).Logger().WithContext(ctx)
+		ctx := log.Ctx(ctx).With().Str("appName", rr.Name).Logger().WithContext(ctx)
 		err := stopRr(ctx, kubeClient, rr)
 		if err != nil {
 			return err
@@ -84,7 +85,7 @@ func stopRr(ctx context.Context, kubeClient *kube.Kube, rr v1.RadixRegistration)
 	}
 
 	for _, rd := range slice.FindAll(rdsForRr, rdIsActive) {
-		ctx = log.Ctx(ctx).With().Str("deployment", rd.Name).Logger().WithContext(ctx)
+		ctx := log.Ctx(ctx).With().Str("deployment", rd.Name).Logger().WithContext(ctx)
 		if err := scaleRdComponentsToZeroReplicas(ctx, kubeClient, rd); err != nil {
 			return err
 		}
@@ -101,10 +102,10 @@ func scaleRdComponentsToZeroReplicas(ctx context.Context, kubeClient *kube.Kube,
 		componentNames = append(componentNames, rd.Spec.Components[i].Name)
 	}
 	_, err := kubeClient.RadixClient().RadixV1().RadixDeployments(rd.Namespace).Update(ctx, &rd, metav1.UpdateOptions{})
-	logger.Info().Msgf("scaled components %s to 0 replicas", strings.Join(componentNames, ", "))
 	if err != nil {
 		return err
 	}
+	logger.Info().Msgf("scaled components %s to 0 replicas", strings.Join(componentNames, ", "))
 	return nil
 }
 


### PR DESCRIPTION
Fixes bug where multiple `appName` and `deployment` fields are appended to logger

```
{"level":"info","appName":"aas-v2-play","appName":"awt-app","deployment":"dev-w3wof-ls4najz1","time":"2024-12-18T09:34:29Z","message":"scaled components frontend, backend to 0 replicas"}
{"level":"info","appName":"aas-v2-play","appName":"awt-app","deployment":"dev-w3wof-ls4najz1","deployment":"test-latest-wgg5yfcq","time":"2024-12-18T09:34:29Z","message":"scaled components frontend, backend to 0 replicas"}
{"level":"info","appName":"aas-v2-play","appName":"awt-app","appName":"co2specdemo","deployment":"dev-yai5h-on8gkovx","time":"2024-12-18T09:34:30Z","message":"scaled components frontend, redis, backend to 0 replicas"}
{"level":"info","appName":"aas-v2-play","appName":"awt-app","appName":"co2specdemo","deployment":"dev-yai5h-on8gkovx","deployment":"test-yai5h-x51nnds4","time":"2024-12-18T09:34:30Z","message":"scaled components frontend, redis, backend to 0 replicas"}
{"level":"info","appName":"aas-v2-play","appName":"awt-app","appName":"co2specdemo","appName":"cow-api","deployment":"dev-kva0a-fvfjyjxj","time":"2024-12-18T09:34:31Z","message":"scaled components cowapi to 0 replicas"}
{"level":"info","appName":"aas-v2-play","appName":"awt-app","appName":"co2specdemo","appName":"cow-api","appName":"datahub","deployment":"dev-erdpl-jwnl9xnw","time":"2024-12-18T09:34:31Z","message":"scaled components www to 0 replicas"}
```